### PR TITLE
fix: Updated to make cert-reflector generic for multiple secrets 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ Kubernetes resources in this repository should be applied in the following order
 Detailed instructions for reflecting the TLS Secret to every namespace can be found in the [BoxBoat Blog post for Kubernetes NGINX Ingress TLS Secrets in All Namespaces](https://boxboat.com/2018/07/02/kubernetes-nginx-ingress-tls-secrets-all-namespaces/)
 
 1. Deploy `ingress-cert-reflector.yml` by running `./ingress-cert-reflector.sh`
+
+## Additional support for multiple secret replication.
+Each secret is attached a label (can be configured via vars.end - REPLICATE_LABEL_NAME and REPLICATE_LABEL_VALUE) and this will be added to the secrets. Cert reflector script will list all secrets containing these labels and sync all those secrets across all namespaces.

--- a/ingress-cert-reflector.sh
+++ b/ingress-cert-reflector.sh
@@ -5,5 +5,5 @@ set -a
 . "vars.env"
 set +a
 
-envsubst '${KUBECTL_VERSION},${TLS_SECRET},${NAMESPACE}' < ingress-cert-reflector.yml \
-    | kubectl apply -f -
+envsubst < ingress-cert-reflector.yml \
+    | kubectl apply -f  -

--- a/ingress-cert-reflector.yml
+++ b/ingress-cert-reflector.yml
@@ -11,16 +11,16 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ingress-cert-reflector
 rules:
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["create", "watch"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  resourceNames: ["${TLS_SECRET}"]
-  verbs: ["get", "patch"]
-- apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "watch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["${TLS_SECRET}"]
+    verbs: ["get", "patch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list", "watch"]
 
 ---
 kind: ClusterRoleBinding
@@ -28,9 +28,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ingress-cert-reflector
 subjects:
-- kind: ServiceAccount
-  name: ingress-cert-reflector
-  namespace: "${NAMESPACE}"
+  - kind: ServiceAccount
+    name: ingress-cert-reflector
+    namespace: "${NAMESPACE}"
 roleRef:
   kind: ClusterRole
   name: ingress-cert-reflector
@@ -54,41 +54,46 @@ spec:
     spec:
       serviceAccountName: ingress-cert-reflector
       containers:
-      - name: ns-watch
-        image: boxboat/kubectl:${KUBECTL_VERSION}
-        command:
-        - sh
-        - -c
-        - |
-          set -e
-          while true; do
-            echo "$(date '+%Y-%m-%d %H:%M:%S') starting watch loop"
-            kubectl get ns --watch --field-selector="status.phase==Active" --no-headers -o "custom-columns=:metadata.name" | \
-            while read ns; do
-              if [ "$ns" != "${NAMESPACE}" ]; then
-                echo "$(date '+%Y-%m-%d %H:%M:%S') namespace - $ns"
-                kubectl -n "${NAMESPACE}" get secret "${TLS_SECRET}" -o yaml --export | \
-                  kubectl -n "$ns" apply -f -
-              fi
-            done
-          done
-      - name: secret-watch
-        image: boxboat/kubectl:${KUBECTL_VERSION}
-        command:
-        - sh
-        - -c
-        - |
-          set -e
-          while true; do
-            echo "$(date '+%Y-%m-%d %H:%M:%S') starting watch loop"
-            kubectl -n "${NAMESPACE}" get secret "${TLS_SECRET}" --watch --no-headers -o "custom-columns=:metadata.name" | \
-            while read secret; do
-              export=$(kubectl -n "${NAMESPACE}" get secret "$secret" -o yaml --export)
-              for ns in $(kubectl get ns --field-selector="status.phase==Active" --no-headers -o "custom-columns=:metadata.name"); do
-                if [ "$ns" != "${NAMESPACE}" ]; then
+        - name: ns-watch
+          image: boxboat/kubectl:${KUBECTL_VERSION}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              while true; do
+                echo "$(date '+%Y-%m-%d %H:%M:%S') starting watch loop"
+                kubectl get ns --watch --field-selector="status.phase==Active" --no-headers -o "custom-columns=:metadata.name" | \
+                while read ns; do
                   echo "$(date '+%Y-%m-%d %H:%M:%S') namespace - $ns"
-                  echo "$export" | kubectl -n "$ns" apply -f -
-                fi
+                  # Added a label based approach to deal with multiple secrets
+                  kubectl -n "${NAMESPACE}" get secret -l ${REPLICATE_LABEL_NAME}==${REPLICATE_LABEL_VALUE} --no-headers -o "custom-columns=:metadata.name" | \
+                  while read secret; do
+                    export=$(kubectl -n "${NAMESPACE}" get secret "$secret" -o yaml --export)
+                    echo "$export" | kubectl -n "$ns" apply -f -
+                    echo "New Secret $secret copied to new namespace $ns"
+                  done
+                done
               done
-            done
-          done
+        - name: secret-watch
+          image: boxboat/kubectl:${KUBECTL_VERSION}
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+              while true; do
+                echo "$(date '+%Y-%m-%d %H:%M:%S') starting watch loop"
+                # Added a label based approach to deal with multiple secrets
+                kubectl -n "${NAMESPACE}" get secret --watch -l ${REPLICATE_LABEL_NAME}==${REPLICATE_LABEL_VALUE} --no-headers -o "custom-columns=:metadata.name" | \
+                while read secret; do
+                  export=$(kubectl -n "${NAMESPACE}" get secret "$secret" -o yaml --export)
+                  for ns in $(kubectl get ns --field-selector="status.phase==Active" --no-headers -o "custom-columns=:metadata.name"); do
+                    if [ "$ns" != "${NAMESPACE}" ]; then
+                      echo "$(date '+%Y-%m-%d %H:%M:%S') namespace - $ns"
+                      echo "$export" | kubectl -n "$ns" apply -f -
+                      echo "New Secret $secret copied to new namespace $ns"
+                    fi
+                  done
+                done
+              done

--- a/lego-generate-cert.yml
+++ b/lego-generate-cert.yml
@@ -9,50 +9,51 @@ spec:
   template:
     spec:
       initContainers:
-      - name: lego
-        image: boxboat/lego:${LEGO_VERSION}
-        args:
-        - --accept-tos
-        - --email=${EMAIL}
-        - --domains=${DOMAIN_1}
-        - --domains=${DOMAIN_2}
-        - --dns=route53
-        - run
-        env:
-        - name: AWS_REGION
-          value: us-east-1
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: lego-aws
-              key: access-key-id
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: lego-aws
-              key: secret-access-key
-        volumeMounts:
-        - name: lego-nfs
-          mountPath: /home/alpine/.lego
+        - name: lego
+          image: boxboat/lego:${LEGO_VERSION}
+          args:
+            - --accept-tos
+            - --email=${EMAIL}
+            - --domains=${DOMAIN_1}
+            - --domains=${DOMAIN_2}
+            - --dns=route53
+            - run
+          env:
+            - name: AWS_REGION
+              value: us-east-1
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: lego-aws
+                  key: access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: lego-aws
+                  key: secret-access-key
+          volumeMounts:
+            - name: lego-nfs
+              mountPath: /home/alpine/.lego
       containers:
-      - name: kubectl
-        image: boxboat/kubectl:${KUBECTL_VERSION}
-        command:
-        - sh
-        - -c
-        - >
-          kubectl create secret tls "${TLS_SECRET}"
-          -n "${NAMESPACE}"
-          --cert=.lego/certificates/${CERT_NAME}.crt
-          --key=.lego/certificates/${CERT_NAME}.key
-          --dry-run
-          -o yaml | kubectl apply -f -
-        volumeMounts:
-        - name: lego-nfs
-          mountPath: /home/alpine/.lego
+        - name: kubectl
+          image: boxboat/kubectl:${KUBECTL_VERSION}
+          command:
+            - sh
+            - -c
+            - >
+              kubectl create secret tls "${TLS_SECRET}"
+              -n "${NAMESPACE}"
+              --cert=.lego/certificates/${CERT_NAME}.crt
+              --key=.lego/certificates/${CERT_NAME}.key
+              --dry-run
+              -o yaml | kubectl apply -f - && \
+              kubectl -n "${NAMESPACE}" label secrets "${TLS_SECRET}" ${REPLICATE_LABEL_NAME}="${REPLICATE_LABEL_VALUE}"
+          volumeMounts:
+            - name: lego-nfs
+              mountPath: /home/alpine/.lego
       restartPolicy: Never
       serviceAccountName: lego
       volumes:
-      - name: lego-nfs
-        persistentVolumeClaim:
-          claimName: lego-nfs
+        - name: lego-nfs
+          persistentVolumeClaim:
+            claimName: lego-nfs

--- a/lego-renew-cert.yml
+++ b/lego-renew-cert.yml
@@ -12,51 +12,52 @@ spec:
       template:
         spec:
           initContainers:
-          - name: lego
-            image: boxboat/lego:${LEGO_VERSION}
-            args:
-            - --accept-tos
-            - --email=${EMAIL}
-            - --domains=${DOMAIN_1}
-            - --domains=${DOMAIN_2}
-            - --dns=route53
-            - renew
-            - --days=30
-            env:
-            - name: AWS_REGION
-              value: us-east-1
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: lego-aws
-                  key: access-key-id
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: lego-aws
-                  key: secret-access-key
-            volumeMounts:
-            - name: lego-nfs
-              mountPath: /home/alpine/.lego
+            - name: lego
+              image: boxboat/lego:${LEGO_VERSION}
+              args:
+                - --accept-tos
+                - --email=${EMAIL}
+                - --domains=${DOMAIN_1}
+                - --domains=${DOMAIN_2}
+                - --dns=route53
+                - renew
+                - --days=30
+              env:
+                - name: AWS_REGION
+                  value: us-east-1
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: lego-aws
+                      key: access-key-id
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: lego-aws
+                      key: secret-access-key
+              volumeMounts:
+                - name: lego-nfs
+                  mountPath: /home/alpine/.lego
           containers:
-          - name: kubectl
-            image: boxboat/kubectl:${KUBECTL_VERSION}
-            command:
-            - sh
-            - -c
-            - >
-              kubectl create secret tls "${TLS_SECRET}"
-              -n "${NAMESPACE}"
-              --cert=.lego/certificates/${CERT_NAME}.crt
-              --key=.lego/certificates/${CERT_NAME}.key
-              --dry-run
-              -o yaml | kubectl apply -f -
-            volumeMounts:
-            - name: lego-nfs
-              mountPath: /home/alpine/.lego
+            - name: kubectl
+              image: boxboat/kubectl:${KUBECTL_VERSION}
+              command:
+                - sh
+                - -c
+                - >
+                  kubectl create secret tls "${TLS_SECRET}"
+                  -n "${NAMESPACE}"
+                  --cert=.lego/certificates/${CERT_NAME}.crt
+                  --key=.lego/certificates/${CERT_NAME}.key
+                  --dry-run
+                  -o yaml | kubectl apply -f - && \
+                  kubectl -n "${NAMESPACE}" label secrets "${TLS_SECRET}" ${REPLICATE_LABEL_NAME}="${REPLICATE_LABEL_VALUE}"
+              volumeMounts:
+                - name: lego-nfs
+                  mountPath: /home/alpine/.lego
           restartPolicy: Never
           serviceAccountName: lego
           volumes:
-          - name: lego-nfs
-            persistentVolumeClaim:
-              claimName: lego-nfs
+            - name: lego-nfs
+              persistentVolumeClaim:
+                claimName: lego-nfs

--- a/vars.env
+++ b/vars.env
@@ -8,3 +8,5 @@ LEGO_VERSION="1.0.1"
 NFS_HOSTNAME="nfs"
 NFS_PATH="/mnt/data/lego"
 TLS_SECRET="ingress-cert"
+REPLICATE_LABEL_NAME=replicate_across_namespaces
+REPLICATE_LABEL_VALUE=true


### PR DESCRIPTION
We are using the cert-reflector in our kubernetes cluster and over a period we had multiple ssl certificates across domains. So we extended this cert-reflector and generalised to support multiple secret replication based on a predefined label attached to each secret artifact.

Please see if this makes sense for everyone else and can be merged back.